### PR TITLE
Update renv.lock

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -60,10 +60,10 @@
     },
     "Matrix": {
       "Package": "Matrix",
-      "Version": "1.3-2",
+      "Version": "1.2-18",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "ff280503079ad8623d3c4b1519b24ea2"
+      "Hash": "08588806cba69f04797dab50627428ed"
     },
     "OpenStreetMap": {
       "Package": "OpenStreetMap",


### PR DESCRIPTION
Newer from source does not compile in windows. reverting to latest version working on all OS

Issue with Matrix package, required by igraph